### PR TITLE
Add tab history to remain functional even with closed tabs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,23 +1,89 @@
-let previousTab;
-let currentTab;
+let tabHistory = {};
+let currentTabId;
+let currentTabJustRemoved = false;
 
 function init() {
+	tabHistory[-1] = {id: null}; // Dummy start.
 	chrome.tabs.query({
 		active: true,
 		lastFocusedWindow: true,
 	}, function(tab) {
-		previousTab = null;
-		currentTab = tab[0].id;
+		currentTabId = tab[0].id;
+		tabHistory[currentTabId] = {id: currentTabId, prev: tabHistory[-1]};
+		tabHistory[-1].next = tabHistory[currentTabId];
+		validateHistory();
 	});
 }
 
 chrome.browserAction.onClicked.addListener(function(tab) {
-	chrome.tabs.update(previousTab, {active: true});
+	let prevTab = tabHistory[currentTabId].prev;
+	if (prevTab.id) { // Check if is dummy start.
+		chrome.tabs.update(prevTab.id, {active: true});
+	}
 });
 
 chrome.tabs.onActivated.addListener(function(info) {
-	previousTab = currentTab;
-	currentTab = info.tabId;
+	// After current tab is closed, this listener is triggered twice. Chrome
+	// first switches to its default tab. Then, we switch to our last tab which
+	// can be identified with `currentTabId`.
+	if (currentTabJustRemoved) {
+		if (info.tabId === currentTabId) {
+			currentTabJustRemoved = false;
+		}
+		return;
+	}
+
+	let prevTabId = currentTabId;
+	currentTabId = info.tabId;
+
+	if (!tabHistory.hasOwnProperty(currentTabId)) { // Newly visited tab.
+		tabHistory[currentTabId] = {id: currentTabId};
+	}
+	let currentTab = tabHistory[currentTabId];
+	if (currentTab.prev) {
+		currentTab.prev.next = currentTab.next;
+		currentTab.next.prev = currentTab.prev;
+	}
+
+	let prevTab = tabHistory[prevTabId];
+	prevTab.next = currentTab;
+	currentTab.prev = prevTab;
+	delete currentTab.next;
+	validateHistory();
 });
+
+chrome.tabs.onRemoved.addListener(function(tabId, info) {
+	if (tabHistory.hasOwnProperty(tabId)) { // Visited tab.
+		// Remove tab from `tabHistory`.
+		let removedTab = tabHistory[tabId];
+		if (tabId === currentTabId) {
+			// Current tab is removed. Switch to the last tab.
+			delete removedTab.prev.next;
+			currentTabJustRemoved = true;
+			currentTabId = removedTab.prev.id;
+			chrome.tabs.update(currentTabId, {active: true});
+		} else {
+			removedTab.prev.next = removedTab.next;
+			removedTab.next.prev = removedTab.prev;
+		}
+		delete tabHistory[tabId];
+	}
+	validateHistory();
+});
+
+function validateHistory() {
+	let current = tabHistory[-1];
+	let path = current.id;
+	while (current.next) {
+		if (current.next.prev !== current) {
+			console.error("Broken history!");
+			console.error(currentTabId, tabHistory);
+			return;
+		}
+		current = current.next;
+		path = path + " => " + current.id;
+	}
+	console.debug(path);
+}
 
 init();


### PR DESCRIPTION
`tabHistory` is a doubly linked list with random access using tab id. A
dummy start is placed at the beginning of the list. Only visited tabs
are added to the list (`tabs.onActivated` listener), and as soon as they
are closed, they're removed from the list (`tabs.onRemoved` listener).

Helper function `validateHistory()` helps out a lot for debugging.

#18 #20 